### PR TITLE
update UFT container to select correct env variable (main)

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -13,11 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ####
-# This script generate server config file dynamically from VF PCI address
-# given in Environment varible exported by device plugin in following
-# format: PCIDEVICE_INTEL_COM_INTEL_ENP24S0F0=0000:18:02.2
+# This script generates a server config file dynamically from VF PCI address
+# provided by network device plugin. The environment variable is in the format:
+# PCIDEVICE_<RESOURCE_NAME>=<PCI_ADDRESSES>
+# E.g - PCIDEVICE_INTEL_COM_INTEL_ENP24S0F0=0000:18:02.2
+#
+# Device plugin also exposes a variable in the format of: 
+# PCIDEVICE_<RESOURCE_NAME>_INFO which contains additional information about 
+# the allocated devices. Information in that variable is not needed by this script
+# and so it is ignored.
 ####
-rawpci=$(env | grep PCIDEVICE_ | awk -F'=' '{ print $2 }')
+rawpci=$(env | grep -P 'PCIDEVICE_[A-Z0-9_]{1,}(?<!_INFO)=' | awk -F'=' '{ print $2 }')
 pciids=(${rawpci//,/ })
 
 SERVER_CONF_FILE=/opt/dcf/server_conf.yaml


### PR DESCRIPTION
This change is for the main branch of the UFT project.

The entrypoint script that is used for building the UFT image uses an environment variable produced by sriov network device plugin. Recent updates to sriov network device plugin has introduced a new environment variable that is being consumed by the entrypoint script and is breaking UFT functionality.

The script is updated to ignore the new environment variable introduced by newer versions of device plugin (with the suffix of _INFO).